### PR TITLE
Replace audio loopback placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,17 +15,17 @@
     <meta property="og:title" content="Audio Loopback Controller - Real-Time Audio Monitoring Tool">
     <meta property="og:description" content="Free web-based audio loopback controller for baby monitoring, hearing assistance, and real-time audio surveillance. Works on all devices.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://your-domain.com">
-    <meta property="og:image" content="https://your-domain.com/audio-controller-preview.jpg">
+    <meta property="og:url" content="https://audio-loopback.vercel.app">
+    <meta property="og:image" content="https://audio-loopback.vercel.app/audio-controller-preview.jpg">
     
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Audio Loopback Controller - Real-Time Audio Monitoring">
     <meta name="twitter:description" content="Professional audio monitoring tool for baby care, hearing assistance, and security surveillance. Free and easy to use.">
-    <meta name="twitter:image" content="https://your-domain.com/audio-controller-preview.jpg">
+    <meta name="twitter:image" content="https://audio-loopback.vercel.app/audio-controller-preview.jpg">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://your-domain.com">
+    <link rel="canonical" href="https://audio-loopback.vercel.app">
     
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -34,7 +34,7 @@
       "@type": "WebApplication",
       "name": "Audio Loopback Controller",
       "description": "Professional audio loopback controller for real-time audio monitoring, baby hearing assistance, and security surveillance",
-      "url": "https://your-domain.com",
+      "url": "https://audio-loopback.vercel.app",
       "applicationCategory": "AudioApplication",
       "operatingSystem": "Web Browser",
       "offers": {


### PR DESCRIPTION
Replace dummy domain placeholders in `index.html` with the actual production URL.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-91198c9d-788d-457f-8631-d5240c13ea40) · [Cursor](https://cursor.com/background-agent?bcId=bc-91198c9d-788d-457f-8631-d5240c13ea40)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)