### PR TITLE
Check sitemap fetch status

### DIFF
--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -2,6 +2,6 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <sitemap>
         <loc>https://audio-loopback.vercel.app/sitemap.xml</loc>
-        <lastmod>2025-01-24</lastmod>
+        <lastmod>2025-01-24T04:38:27+00:00</lastmod>
     </sitemap>
 </sitemapindex>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,26 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://audio-loopback.vercel.app/</loc>
-        <lastmod>2025-01-24</lastmod>
+        <lastmod>2025-01-24T04:38:27+00:00</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
-    </url>
-    <url>
-        <loc>https://audio-loopback.vercel.app/#features</loc>
-        <lastmod>2025-01-24</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
-    </url>
-    <url>
-        <loc>https://audio-loopback.vercel.app/#faq</loc>
-        <lastmod>2025-01-24</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.7</priority>
-    </url>
-    <url>
-        <loc>https://audio-loopback.vercel.app/#privacy</loc>
-        <lastmod>2025-01-24</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.6</priority>
     </url>
 </urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=3600, s-maxage=3600"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
         }
       ]
     },
@@ -23,6 +27,10 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=3600, s-maxage=3600"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
         }
       ]
     },
@@ -38,6 +46,16 @@
           "value": "public, max-age=3600, s-maxage=3600"
         }
       ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/sitemap.xml",
+      "destination": "/sitemap.xml"
+    },
+    {
+      "source": "/sitemap-index.xml", 
+      "destination": "/sitemap-index.xml"
     }
   ]
 }


### PR DESCRIPTION
Update sitemap format and Vercel config to resolve Google Search Console 'Couldn't fetch' errors.

The "Couldn't fetch" error in Google Search Console was likely due to improper date formats, fragment URLs in sitemaps, or server configuration. This PR addresses these by updating `lastmod` to ISO 8601, removing fragment URLs, and adding explicit Vercel rewrites and `X-Robots-Tag: noindex` headers for sitemaps.

---

[Open in Web](https://www.cursor.com/agents?id=bc-afb5adbc-47ac-4ad9-aa50-7c346858000a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-afb5adbc-47ac-4ad9-aa50-7c346858000a)